### PR TITLE
remove checkbox

### DIFF
--- a/src/config/layerExpression.json
+++ b/src/config/layerExpression.json
@@ -5,12 +5,6 @@
     "operator": " AND ",
     "expressions": [
       {
-        "id": 0,
-        "definitionExpression": "site IS NOT NULL",
-        "name": "Has Attachment",
-        "index": 0
-      },
-      {
         "id": 1,
         "name": "Site",
         "type": "string",


### PR DESCRIPTION
Remove checkbox for the "has attachment" filter. Customer is responsible to modify their own data and remove points without attachments