### PR TITLE
refresh features on filter change

### DIFF
--- a/src/app/Components/PhotoCentric.tsx
+++ b/src/app/Components/PhotoCentric.tsx
@@ -764,7 +764,10 @@ class PhotoCentric extends Widget {
               id="filter-list"
               layerExpressions={layerExpression}
               view={this.view?.map}
-              onfilterUpdate={this._zoomToResultExtent}
+              onfilterUpdate={() => {
+                this._zoomToResultExtent();
+                this.viewModel.refreshFeatures();
+              }}
             ></instant-apps-filter-list>
           </div>
         ) : null}
@@ -2205,7 +2208,8 @@ c6.6,0,12-5.4,12-12S18.6,0,12,0L12,0z"
   }
 
   private _zoomToResultExtent(): void {
-    const layerId = layerExpression[0].id;
+    const featureLayer = this.selectedAttachmentViewerData?.get("layerData.featureLayer") as __esri.FeatureLayer;
+    const layerId = featureLayer.id;
     const allLayers = this.view?.map.allLayers.items;
 
     for (const layer of allLayers) {


### PR DESCRIPTION
refreshes features when definition expression / filter changes.

This fixes bug where you can toggle through "hidden" features affected by filter using the left and right buttons